### PR TITLE
Fix steamclient.so path

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 SCRIPT_DIR=$PWD
 curl -s https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz | tar -vxz
-cp -f linux64/steamclient.so Unturned_Headless_Data/Plugins/x86_64/steamclient.so
 
 # Update / install server
 ./steamcmd.sh +login $STEAM_USERNAME $STEAM_PASSWORD $STEAM_GUARD_TOKEN $STEAM_CMD_ARGS +force_install_dir $GAME_INSTALL_DIR +@sSteamCmdForcePlatformBitness 64 +app_update $GAME_ID +quit
+
+# Move the steamclient
+mkdir -p /home/steam/.steam/sdk64/
+cp -f linux64/steamclient.so /home/steam/.steam/sdk64/steamclient.so
 
 # Optionlly install RocketMod
 export MODULES_DIR=$GAME_INSTALL_DIR/Modules


### PR DESCRIPTION
This PR is a fix for issue #2.

### Summary of changes

* Changed the path for `steamclient.so` to `/home/steam/.steam/sdk64/steamclient.so` as the newest SteamAPI expects the shared object to be there instead of `Unturned_Headless_Data/Plugins/x86_64/steamclient.so`.

* The copying (`cp`) of the shared object / module is also moved a little further down as the file (`steamclient.so`) is not downloaded until after `steamcmd.sh` is finished.